### PR TITLE
refactor use f32::clamp (introduced in Rust 1.50)

### DIFF
--- a/src/util/bounds.rs
+++ b/src/util/bounds.rs
@@ -142,7 +142,7 @@ impl Bounds {
     /// align is the start-to-end relative position (0.0 - 1.0)
     #[inline]
     pub fn inner_aligned_f(&self, size: (f32,f32), align: (f32,f32)) -> Self {
-        let align = (align.0.min(1.0).max(0.0), align.1.min(1.0).max(0.0));
+        let align = (align.0.clamp(0.0,1.0), align.1.clamp(0.0,1.0));
         let nx = (self.size.w as f32 - size.0)*align.0;
         let ny = (self.size.h as f32 - size.1)*align.1;
         let nw = ((nx+size.0) as i32 - nx as i32) as u32;

--- a/src/widgets/pbar/widget.rs
+++ b/src/widgets/pbar/widget.rs
@@ -79,7 +79,7 @@ pub fn crop(i: &Bounds, v: f32, o: Orientation) -> Bounds {
     let (x, w) = i.par(o);
     let (y, h) = i.unpar(o);
 
-    let w = ((w as f32) * v.max(0.0).min(1.0) ) as u32;
+    let w = ((w as f32) * v.clamp(0.0,1.0) ) as u32;
 
     Bounds::from_ori(x, y, w, h, o)
 }

--- a/src/widgets/splitpane/widget.rs
+++ b/src/widgets/splitpane/widget.rs
@@ -190,7 +190,7 @@ impl<'w,E,L,R,V> SplitPane<'w,E,L,R,V> where
         let o = self.orientation;
         let (x,w) = b.par(o);
         let (y,h) = b.unpar(o);
-        let w0 = ((w as f32 - handle_width as f32)*v.max(0.0).min(1.0)) as u32;
+        let w0 = ((w as f32 - handle_width as f32)*v.clamp(0.0,1.0)) as u32;
         let w2 = w - w0 - handle_width;
         let x1 = x + w0 as i32;
         let x2 = x1 + handle_width as i32;


### PR DESCRIPTION
simplifies code, but bumps rust minimum to 1.50