### PR TITLE
Reconcept Path resolve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ferionve/guion"
 readme = "README.md"
 
 [dependencies]
-qwutils = { version = "0.3.0", git = "https://github.com/qwertz19281/rust_utils", rev = "7959b3c0134fa864c1fd50adbeb063cbfe28e092" }
+qwutils = { version = "0.3.1", git = "https://github.com/qwertz19281/rust_utils", rev = "833f581b5e63117fb87a7dad9f41a6532113fd88" }
 #qwutils = { path = "../qwutils" }
 
 [profile.release]

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -22,8 +22,6 @@ pub type ECQueue<E: Env> = <E::Context as Context<E>>::Queue;
 pub type ECStdState<E: Env> = <E::Context as CtxStdState<E>>::T;
 pub type EPressedKey<E: Env> = <ECStdState<E> as StdState<E>>::K;
 
-pub type EWPSub<E: Env> = <E::WidgetPath as WidgetPath<E>>::SubPath;
-
 pub type CtxRef<'a,E: Env> = (&'a E::Storage,&'a mut E::Context);
 pub type CtxRefR<'a,E: Env> = (&'a E::Storage,&'a E::Context);
 pub type CtxRefM<'a,E: Env> = (&'a mut E::Storage,&'a mut E::Context);

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -35,7 +35,7 @@ impl<E> Filter<E> for StdFilter<E> where E: Env, EEFilter<E>: From<Self> {
     }
 
     fn attach_path_prefix(mut self, prefix: E::WidgetPath) -> Self {
-        self.filter_path = prefix.attached_path(&self.filter_path);
+        self.filter_path = prefix.attached_subpath(&self.filter_path);
         self
     }
 }

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -18,10 +18,10 @@ pub struct StdFilter<E> where E: Env, EEFilter<E>: From<Self> {
 impl<E> Filter<E> for StdFilter<E> where E: Env, EEFilter<E>: From<Self> {
     fn _filter(&self, dest: &Link<E>, e: &EventCompound<E>) -> Option<EventCompound<E>> {
         if !self.filter_path.is_empty() {
-            dest.widget.resolves_by(self.filter_path.index(0).unwrap())
-                .map(#[inline] || EventCompound{
+            dest.widget.resolved_by_path(&self.filter_path)
+                .map(#[inline] |r| EventCompound{
                     filter: StdFilter{
-                        filter_path: self.filter_path.slice(1..),
+                        filter_path: r.sub_path,
                         filter_bounds: self.filter_bounds,
                     }.into(),
                     ..e.clone()

--- a/src/id/standard.rs
+++ b/src/id/standard.rs
@@ -58,16 +58,9 @@ impl<E> SubPath<E> for StdID where E: Env, E::WidgetID: Into<Self> + From<Self> 
     fn into_id(self) -> E::WidgetID {
         self.into()
     }
-
     #[inline]
-    fn resolves_to_id(&self, id: E::WidgetID) -> bool {
-        self == &id.into()
-    }
-    #[inline]
-    fn resolves_to_path(&self, p: E::WidgetPath) -> bool {
-        p.tip().map_or(false,#[inline] |tip| { //TODO verify correctness of None => false
-            *self == tip.clone().into_id().into()
-        })
+    fn resolve_to_same_widget(&self, o: &Self) -> bool {
+        self == o
     }
 
     fn is<T: Any>(&self) -> bool { //TODO default underlying-trait impl hack
@@ -82,7 +75,6 @@ impl<E> SubPath<E> for StdID where E: Env, E::WidgetID: Into<Self> + From<Self> 
     fn downcast_into<T: Any>(self) -> Result<T,Self> where Self: Sized + 'static {
         todo!()
     }
-    
 }
 
 #[allow(unused)]

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -20,29 +20,22 @@ pub trait WidgetPath<E>:
     Sync +
     'static
 where E: Env {
-    type SubPath: SubPath<E>;
-    
-    // TODO rename to attach_sub
-    fn attach(&mut self, sub: Self::SubPath);
-    #[inline]
-    fn attached(mut self, sub: Self::SubPath) -> Self {
-        self.attach(sub);
-        self
-    }
+
 
     // TODO rename to attach_path
-    fn attach_path(&mut self, sub: &Self);
+    fn attach_subpath(&mut self, sub: &Self);
     #[inline]
-    fn attached_path(mut self, sub: &Self) -> Self {
-        self.attach_path(sub);
+    fn attached_subpath(mut self, sub: &Self) -> Self {
+        self.attach_subpath(sub);
         self
     }
 
-    /// IMPL
-    /// does the sub path from the parent path resolve to or through the specific child widget of the parent widget?
-    /// [`parent_path`]: absolute path of the current parent widget
-    /// [`child`]: child widget of parent widget to which the sub path probably resolves to/through
-    /// [`sub_path`]: relative sub path to which widget should be attempted to resolve
+    /// IMPL  
+    /// Does the sub path from the parent path resolve to or through the specific child widget of the parent widget?  
+    // returns None only of sub_path wouldn't resolve to or through the given child widget
+    /// [`parent_path`]: Absolute path of the current parent widget  
+    /// [`child`]: Child widget of parent widget to which the sub path probably resolves to/through  
+    /// [`sub_path`]: Relative sub path to which widget should be attempted to resolve  
     fn resolves_thru_child_id(child: E::WidgetID, sub_path: &Self) -> Option<ResolvesThruResult<E>>;
     fn resolves_thru_child_path(child_path: &Self, sub_path: &Self) -> Option<ResolvesThruResult<E>>;
 
@@ -50,16 +43,24 @@ where E: Env {
     fn for_child_widget_path(&self, child_path: &Self) -> Self;
 
 
-    fn tip(&self) -> Option<&Self::SubPath>;
+    // fn tip(&self) -> Option<&Self::SubPath>;
+    /// returns the targeted widget ID if available
+    /// NOTE this function is implemented optionally, so it may never return ID, even if possible
+    fn _dest_widget(&self) -> Option<E::WidgetID> {
+        None
+    }
+    #[deprecated]
     fn exact_eq(&self, o: &Self) -> bool;
 
+    /// If self and o would resolve to the same widget
+    fn dest_eq(&self, o: &Self) -> bool;
+
+    /// the path which would resolve to the parent widget
+    /// returns None only if the path is empty
     fn parent(&self) -> Option<Self>;
 
     /// if the path is empty e.g. doesn't resolve further
     fn is_empty(&self) -> bool;
-
-    fn slice<T>(&self, range: T) -> Self where T: RangeBounds<usize>;
-    fn index<T>(&self, i: T) -> Option<&Self::SubPath> where T: SliceIndex<[Self::SubPath],Output=Self::SubPath>;
 
     fn empty() -> Self;
 

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -38,11 +38,21 @@ where E: Env {
         self
     }
 
+    /// IMPL
+    /// does the sub path from the parent path resolve to or through the specific child widget of the parent widget?
+    /// [`parent_path`]: absolute path of the current parent widget
+    /// [`child`]: child widget of parent widget to which the sub path probably resolves to/through
+    /// [`sub_path`]: relative sub path to which widget should be attempted to resolve
+    fn _resolves_thru<W>(child: &W, sub_path: &Self) -> Option<ResolvesThruResult<E>> where W: Widget<E>+?Sized;
+
+    fn for_child_widget<W>(&self, child: &W) -> Self where W: Widget<E>+?Sized;
+
     fn tip(&self) -> Option<&Self::SubPath>;
     fn exact_eq(&self, o: &Self) -> bool;
 
     fn parent(&self) -> Option<Self>;
 
+    /// if the path is empty e.g. doesn't resolve further
     fn is_empty(&self) -> bool;
 
     fn slice<T>(&self, range: T) -> Self where T: RangeBounds<usize>;
@@ -54,6 +64,11 @@ where E: Env {
     fn with_env<F: Env<WidgetPath=E::WidgetPath>>(self) -> Self where E::WidgetPath: WidgetPath<F> {
         self
     }
+}
+
+pub struct ResolvesThruResult<E> where E: Env {
+    /// the sub path inside the current child widget which resolves further
+    pub sub_path: E::WidgetPath,
 }
 
 #[inline]

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -43,9 +43,12 @@ where E: Env {
     /// [`parent_path`]: absolute path of the current parent widget
     /// [`child`]: child widget of parent widget to which the sub path probably resolves to/through
     /// [`sub_path`]: relative sub path to which widget should be attempted to resolve
-    fn _resolves_thru<W>(child: &W, sub_path: &Self) -> Option<ResolvesThruResult<E>> where W: Widget<E>+?Sized;
+    fn resolves_thru_child_id(child: E::WidgetID, sub_path: &Self) -> Option<ResolvesThruResult<E>>;
+    fn resolves_thru_child_path(child_path: &Self, sub_path: &Self) -> Option<ResolvesThruResult<E>>;
 
-    fn for_child_widget<W>(&self, child: &W) -> Self where W: Widget<E>+?Sized;
+    fn for_child_widget_id(&self, child: E::WidgetID) -> Self;
+    fn for_child_widget_path(&self, child_path: &Self) -> Self;
+
 
     fn tip(&self) -> Option<&Self::SubPath>;
     fn exact_eq(&self, o: &Self) -> bool;

--- a/src/path/standard.rs
+++ b/src/path/standard.rs
@@ -70,6 +70,24 @@ impl<E,S> WidgetPath<E> for SimplePath<E,S> where
             _p: PhantomData,
         }
     }
+
+    fn _resolves_thru<W>(child: &W, sub_path: &Self) -> Option<ResolvesThruResult<E>> where W: Widget<E>+?Sized {
+        let sub_path_dest_id = sub_path.index(0).unwrap().clone().into_id(); //TODO deprecated old PathSub thing
+        let child_id = child.id();
+        if child_id == sub_path_dest_id {
+            // sub_path does indeed resolve to or through child
+            Some(ResolvesThruResult{
+                //TODO optimize .clone().attached() efficiency
+                sub_path: sub_path.slice(1..).into(),
+            })
+        }else{
+            None
+        }
+    }
+
+    fn for_child_widget<W>(&self, child: &W) -> Self where W: Widget<E>+?Sized {
+        self.clone().attached(SubPath::from_id(child.id()))
+    }
 }
 
 impl<E,S> SimplePath<E,S> where E: Env, S: SubPath<E> + Send+Sync + 'static {

--- a/src/path/sub.rs
+++ b/src/path/sub.rs
@@ -5,7 +5,6 @@ pub trait SubPath<E>:
     Clone +
     PartialEq<Self> +
     Sized +
-    Debug +
 where E: Env {
     fn from_id(id: E::WidgetID) -> Self;
     fn _eq_id(&self, id: E::WidgetID) -> bool;

--- a/src/path/sub.rs
+++ b/src/path/sub.rs
@@ -1,16 +1,17 @@
 use super::*;
 
+#[deprecated]
 pub trait SubPath<E>:
     Clone +
     PartialEq<Self> +
     Sized +
+    Debug +
 where E: Env {
     fn from_id(id: E::WidgetID) -> Self;
     fn _eq_id(&self, id: E::WidgetID) -> bool;
     fn into_id(self) -> E::WidgetID;
 
-    fn resolves_to_id(&self, id: E::WidgetID) -> bool;
-    fn resolves_to_path(&self, p: E::WidgetPath) -> bool;
+    fn resolve_to_same_widget(&self, o: &Self) -> bool;
 
     fn is<T: Any>(&self) -> bool;
     fn downcast_ref<T: Any>(&self) -> Option<&T>;

--- a/src/state/standard/kbd/tabulate.rs
+++ b/src/state/standard/kbd/tabulate.rs
@@ -36,7 +36,7 @@ pub fn tabulate<E: Env>(s: &E::Storage, selected: E::WidgetPath, reverse: bool) 
                 if let Ok(w) = s.widget(parent.refc()) {
                     let pc = w.child_paths();
 
-                    let idx = pc.iter().position(|c| c.tip() == current.tip() ).expect("Parent Lost Child Widget");
+                    let idx = pc.iter().position(|c| c.dest_eq(current) ).expect("Parent Lost Child Widget");
 
                     if idx < pc.len()-1 {
                         *current = pc[idx+1].clone();
@@ -54,7 +54,7 @@ pub fn tabulate<E: Env>(s: &E::Storage, selected: E::WidgetPath, reverse: bool) 
             if let Ok(w) = s.widget(parent.refc()) {
                 let pc = w.child_paths();
 
-                let idx = pc.iter().position(|c| c.tip() == current.tip() ).expect("Parent Lost Child Widget");
+                let idx = pc.iter().position(|c| c.dest_eq(current) ).expect("Parent Lost Child Widget");
 
                 if idx > 0 {
                     *current = pc[idx-1].clone();
@@ -105,7 +105,7 @@ pub fn tabulate_old<E: Env>(s: &E::Storage, selected: E::WidgetPath, reverse: bo
             if let Some(p) = current.parent() {
                 let pc = w.child_paths();
                 //find current child in parent
-                let idx = pc.iter().position(|c| c.tip() == current.tip() ).expect("Parent Lost Child Widget");
+                let idx = pc.iter().position(|c| c.dest_eq(&current) ).expect("Parent Lost Child Widget");
 
                 if !reverse && idx < pc.len()-1 {
                     //traverse into next silbing

--- a/src/widget/ident.rs
+++ b/src/widget/ident.rs
@@ -17,7 +17,11 @@ impl<E> WidgetIdent<E> where E: Env {
     /// Resolves the Widget
     #[inline]
     pub fn from_path(path: E::WidgetPath, stor: &E::Storage) -> Result<Self,()> {
-        stor.widget(path).map(#[inline] |r| r.ident() )
+        if let Some(id) = path._dest_widget() {
+            Ok(Self{id,path})
+        }else{
+            stor.widget(path).map(#[inline] |r| r.ident() )
+        }
     }
 }
 

--- a/src/widget/imp.rs
+++ b/src/widget/imp.rs
@@ -55,7 +55,7 @@ impl<E> Widget<E> for &(dyn Widget<E>+'_) where E: Env {
         (**self).resolve(i)
     }
     #[inline]
-    fn resolve_child(&self, p: &EWPSub<E>) -> Result<usize,()> {
+    fn resolve_child(&self, p: &E::WidgetPath) -> Result<(usize,E::WidgetPath),()>  {
         (**self).resolve_child(p)
     }
     #[inline]
@@ -67,8 +67,8 @@ impl<E> Widget<E> for &(dyn Widget<E>+'_) where E: Env {
         (**self).in_parent_path(parent)
     }
     #[inline]
-    fn resolves_by(&self, p: &EWPSub<E>) -> bool {
-        (**self).resolves_by(p)
+    fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
+        (**self).resolved_by_path(sub_path)
     }
     #[inline]
     fn _focus_on_mouse_down(&self) -> bool {
@@ -161,7 +161,7 @@ impl<E> Widget<E> for &mut (dyn Widget<E>+'_) where E: Env {
         (**self).resolve(i)
     }
     #[inline]
-    fn resolve_child(&self, p: &EWPSub<E>) -> Result<usize,()> {
+    fn resolve_child(&self, p: &E::WidgetPath) -> Result<(usize,E::WidgetPath),()>  {
         (**self).resolve_child(p)
     }
     #[inline]
@@ -173,8 +173,8 @@ impl<E> Widget<E> for &mut (dyn Widget<E>+'_) where E: Env {
         (**self).in_parent_path(parent)
     }
     #[inline]
-    fn resolves_by(&self, p: &EWPSub<E>) -> bool {
-        (**self).resolves_by(p)
+    fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
+        (**self).resolved_by_path(sub_path)
     }
     #[inline]
     fn _focus_on_mouse_down(&self) -> bool {
@@ -267,7 +267,7 @@ impl<E> Widget<E> for &(dyn WidgetMut<E>+'_) where E: Env {
         (**self).resolve(i)
     }
     #[inline]
-    fn resolve_child(&self, p: &EWPSub<E>) -> Result<usize,()> {
+    fn resolve_child(&self, p: &E::WidgetPath) -> Result<(usize,E::WidgetPath),()>  {
         (**self).resolve_child(p)
     }
     #[inline]
@@ -279,8 +279,8 @@ impl<E> Widget<E> for &(dyn WidgetMut<E>+'_) where E: Env {
         (**self).in_parent_path(parent)
     }
     #[inline]
-    fn resolves_by(&self, p: &EWPSub<E>) -> bool {
-        (**self).resolves_by(p)
+    fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
+        (**self).resolved_by_path(sub_path)
     }
     #[inline]
     fn _focus_on_mouse_down(&self) -> bool {
@@ -374,7 +374,7 @@ impl<E> Widget<E> for &mut (dyn WidgetMut<E>+'_) where E: Env {
         (**self).resolve(i)
     }
     #[inline]
-    fn resolve_child(&self, p: &EWPSub<E>) -> Result<usize,()> {
+    fn resolve_child(&self, p: &E::WidgetPath) -> Result<(usize,E::WidgetPath),()>  {
         (**self).resolve_child(p)
     }
     #[inline]
@@ -386,8 +386,8 @@ impl<E> Widget<E> for &mut (dyn WidgetMut<E>+'_) where E: Env {
         (**self).in_parent_path(parent)
     }
     #[inline]
-    fn resolves_by(&self, p: &EWPSub<E>) -> bool {
-        (**self).resolves_by(p)
+    fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
+        (**self).resolved_by_path(sub_path)
     }
     #[inline]
     fn _focus_on_mouse_down(&self) -> bool {
@@ -532,7 +532,7 @@ impl<E> Widget<E> for Box<(dyn Widget<E>+'_)> where E: Env {
         (*self).into_resolve(i)
     }
     #[inline]
-    fn resolve_child(&self, p: &EWPSub<E>) -> Result<usize,()> {
+    fn resolve_child(&self, p: &E::WidgetPath) -> Result<(usize,E::WidgetPath),()>  {
         (**self).resolve_child(p)
     }
     #[inline]
@@ -544,8 +544,8 @@ impl<E> Widget<E> for Box<(dyn Widget<E>+'_)> where E: Env {
         (**self).in_parent_path(parent)
     }
     #[inline]
-    fn resolves_by(&self, p: &EWPSub<E>) -> bool {
-        (**self).resolves_by(p)
+    fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
+        (**self).resolved_by_path(sub_path)
     }
     #[inline]
     fn _focus_on_mouse_down(&self) -> bool {
@@ -637,7 +637,7 @@ impl<E> Widget<E> for Box<(dyn WidgetMut<E>+'_)> where E: Env {
         (*self).into_resolve(i)
     }
     #[inline]
-    fn resolve_child(&self, p: &EWPSub<E>) -> Result<usize,()> {
+    fn resolve_child(&self, p: &E::WidgetPath) -> Result<(usize,E::WidgetPath),()>  {
         (**self).resolve_child(p)
     }
     #[inline]
@@ -649,8 +649,8 @@ impl<E> Widget<E> for Box<(dyn WidgetMut<E>+'_)> where E: Env {
         (**self).in_parent_path(parent)
     }
     #[inline]
-    fn resolves_by(&self, p: &EWPSub<E>) -> bool {
-        (**self).resolves_by(p)
+    fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
+        (**self).resolved_by_path(sub_path)
     }
     #[inline]
     fn _focus_on_mouse_down(&self) -> bool {

--- a/src/widget/link/mod.rs
+++ b/src/widget/link/mod.rs
@@ -185,7 +185,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     /// Get Link for specific child by index
     #[inline]
-    pub fn for_child<'s>(&'s mut self, i: usize) -> Result<Link<E>,()> where 'c: 's {
+    pub fn for_child<'s>(&'s mut self, i: usize) -> Result<Link<E>,()> where 'c: 's { //TODO rename to child(i)
         let path = self.widget.path.refc();
         let stor = self.widget.stor;
 

--- a/src/widget/link/mod.rs
+++ b/src/widget/link/mod.rs
@@ -263,7 +263,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
 
     pub fn resolve_sub<'s>(&'s mut self, p: E::WidgetPath) -> Result<Link<'s,E>,()> where 'c: 's {
-        let mut new_path = self.widget.path.refc().attached_path(&p);
+        let mut new_path = self.widget.path.refc().attached_subpath(&p); //TODO w h a t
         let rw = self.widget.wref.resolve(p.refc())?;
         rw.extract_path(&mut new_path);
         let rw = rw.resolve_widget(&self.widget.stor)?;
@@ -306,7 +306,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     
     #[inline]
-    pub fn with_ctx<F: Env<WidgetPath=E::WidgetPath,Storage=E::Storage>>(self, ctx: &'c mut F::Context) -> Link<'c,F> where E::WidgetPath: WidgetPath<F,SubPath=EWPSub<E>>, EWPSub<E>: SubPath<F>, E::Storage: Widgets<F> {
+    pub fn with_ctx<F: Env<WidgetPath=E::WidgetPath,Storage=E::Storage>>(self, ctx: &'c mut F::Context) -> Link<'c,F> where E::WidgetPath: WidgetPath<F>, E::Storage: Widgets<F> {
         Link{
             widget: self.widget.with_env::<F>(),
             ctx,

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -75,8 +75,8 @@ pub trait Widget<E>: WBase<E> where E: Env + 'static {
         if i.is_empty() {
             return Ok(Resolvable::Widget(self.box_ref()))
         }
-        let c = self.resolve_child(i.index(0).unwrap())?;
-        self.child(c).unwrap().resolve_child(i.slice(1..))
+        let (c,sub) = self.resolve_child(&i)?;
+        self.child(c).unwrap().resolve_child(sub)
     }
     /// ![RESOLVING](https://img.shields.io/badge/-resolving-000?style=flat-square)  
     /// resolve a deep child item by the given relative path  
@@ -87,18 +87,18 @@ pub trait Widget<E>: WBase<E> where E: Env + 'static {
         if i.is_empty() {
             return Ok(Resolvable::Widget(self.box_box()))
         }
-        let c = self.resolve_child(i.index(0).unwrap())?;
-        self.into_child(c).unwrap_nodebug().resolve_child(i.slice(1..))
+        let (c,sub) = self.resolve_child(&i)?;
+        self.into_child(c).unwrap_nodebug().resolve_child(sub)
     }
     /// ![RESOLVING](https://img.shields.io/badge/-resolving-000?style=flat-square)  
-    /// resolve a deep child item by the given relative path  
-    /// an empty path will resolve to this widget  
+    /// to (or through) which child path would the given sub_path resolve?
+    /// returns the child index and the subpath inside the child widget to resolve further
     /// ![USER](https://img.shields.io/badge/-user-0077ff?style=flat-square) generally not used directly, but throught [`Widgets::widget`](Widgets::widget)
     #[inline]
-    fn resolve_child(&self, p: &EWPSub<E>) -> Result<usize,()> {
+    fn resolve_child(&self, sub_path: &E::WidgetPath) -> Result<(usize,E::WidgetPath),()> { //TODO descriptive struct like ResolvesThruResult instead confusing tuple
         for c in 0..self.childs() {
-            if self.child(c).unwrap().resolves_by(p) {
-                return Ok(c);
+            if let Some(r) = self.child(c).unwrap().resolved_by_path(sub_path) {
+                return Ok((c,r.sub_path));
             }
         }
         Err(())
@@ -109,7 +109,7 @@ pub trait Widget<E>: WBase<E> where E: Env + 'static {
         if i.is_empty() {
             return Ok(*b)
         }
-        let child = self.resolve_child(i.index(0).unwrap())?;
+        let (child,_) = self.resolve_child(&i)?;
         let bounds = self.child_bounds(l,b,e,force)?;
         
         Ok(bounds[child])
@@ -121,13 +121,13 @@ pub trait Widget<E>: WBase<E> where E: Env + 'static {
     /// attach widget's id to the given parent path
     #[inline]
     fn in_parent_path(&self, parent: E::WidgetPath) -> E::WidgetPath {
-        parent.attached(SubPath::from_id(self.id()))
+        parent.for_child_widget(self)
     }
     /// ![RESOLVING](https://img.shields.io/badge/-resolving-000?style=flat-square)  
-    /// if the path segment would resolve to this widget
-    #[inline]
-    fn resolves_by(&self, p: &EWPSub<E>) -> bool {
-        p.resolves_to_id(self.id())
+    /// Refer [`WidgetPath::_resolves_thru`](WidgetPath::_resolves_thru)
+    /// [`sub_path`]: subpath in parent widget (which contains this widget as child) which would probably resolve to/through this widget
+    fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
+        E::WidgetPath::_resolves_thru(self, sub_path)
     }
 
     /// if the widget should be focusable.  
@@ -216,8 +216,8 @@ pub trait WidgetMut<E>: Widget<E> + WBaseMut<E> where E: Env + 'static {
         if i.is_empty() {
             return Ok(ResolvableMut::Widget(self.box_mut()))
         }
-        let c = self.resolve_child(i.index(0).unwrap())?;
-        self.child_mut(c).unwrap().resolve_child_mut(i.slice(1..))
+        let (c,sub) = self.resolve_child(&i)?;
+        self.child_mut(c).unwrap().resolve_child_mut(sub)
     }
 
     /// ![RESOLVING](https://img.shields.io/badge/-resolving-000?style=flat-square)  
@@ -229,8 +229,8 @@ pub trait WidgetMut<E>: Widget<E> + WBaseMut<E> where E: Env + 'static {
         if i.is_empty() {
             return Ok(ResolvableMut::Widget(self.box_box_mut()))
         }
-        let c = self.resolve_child(i.index(0).unwrap())?;
-        self.into_child_mut(c).unwrap_nodebug().resolve_child_mut(i.slice(1..))
+        let (c,sub) = self.resolve_child(&i)?;
+        self.into_child_mut(c).unwrap_nodebug().resolve_child_mut(sub)
     }
 
     #[inline]

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -120,14 +120,16 @@ pub trait Widget<E>: WBase<E> where E: Env + 'static {
     /// ![RESOLVING](https://img.shields.io/badge/-resolving-000?style=flat-square)  
     /// attach widget's id to the given parent path
     #[inline]
+    #[deprecated]
     fn in_parent_path(&self, parent: E::WidgetPath) -> E::WidgetPath {
-        parent.for_child_widget(self)
+        parent.for_child_widget_id(self.id())
     }
     /// ![RESOLVING](https://img.shields.io/badge/-resolving-000?style=flat-square)  
     /// Refer [`WidgetPath::_resolves_thru`](WidgetPath::_resolves_thru)
     /// [`sub_path`]: subpath in parent widget (which contains this widget as child) which would probably resolve to/through this widget
+    #[deprecated]
     fn resolved_by_path(&self, sub_path: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
-        E::WidgetPath::_resolves_thru(self, sub_path)
+        E::WidgetPath::resolves_thru_child_id(self.id(), sub_path)
     }
 
     /// if the widget should be focusable.  

--- a/src/widget/resolvable.rs
+++ b/src/widget/resolvable.rs
@@ -41,9 +41,7 @@ impl<'w,E> Resolvable<'w,E> where E: Env + 'static {
     pub fn resolved_by_path(&self, p: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
         match self {
             Resolvable::Widget(w) => w.resolved_by_path(p),
-            Resolvable::Path(w) => 
-                p.index(0).unwrap().resolves_to_path(w.refc())
-                    .then(|| ResolvesThruResult{ sub_path: p.slice(1..) } ) //TODO this is wrong, as the WidgetID isn't in the WidgetPath, so the current hack relies on the StdPath indeed having the last destination WidgetID. Resolving this requires architecturial modifications, either to enable resolving in this function, which requies the resolve fns to carry &E::Storage for resolving, which is ony possible in the immutable space. Alternatively path needs to somehow carry the last(dest) ID, which doesn't seem to be possible.
+            Resolvable::Path(w) => E::WidgetPath::resolves_thru_child_path(w,p) //TODO this is wrong, as the WidgetID isn't in the WidgetPath, so the current hack relies on the StdPath indeed having the last destination WidgetID. Resolving this requires architecturial modifications, either to enable resolving in this function, which requies the resolve fns to carry &E::Storage for resolving, which is ony possible in the immutable space. Alternatively path needs to somehow carry the last(dest) ID, which doesn't seem to be possible.
         }
     }
     /// extend the path representing the parent of this widget to resolve to this widget
@@ -103,9 +101,7 @@ impl<'w,E> ResolvableMut<'w,E> where E: Env {
     pub fn resolved_by_path(&self, p: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
         match self {
             ResolvableMut::Widget(w) => w.resolved_by_path(p),
-            ResolvableMut::Path(w) => 
-                p.index(0).unwrap().resolves_to_path(w.refc())
-                    .then(|| ResolvesThruResult{ sub_path: p.slice(1..) } ) //TODO this is wrong, as the WidgetID isn't in the WidgetPath, so the current hack relies on the StdPath indeed having the last destination WidgetID. Resolving this requires architecturial modifications, either to enable resolving in this function, which requies the resolve fns to carry &E::Storage for resolving, which is ony possible in the immutable space. Alternatively path needs to somehow carry the last(dest) ID, which doesn't seem to be possible.
+            ResolvableMut::Path(w) => E::WidgetPath::resolves_thru_child_path(w,p)
         }
     }
 }

--- a/src/widget/resolvable.rs
+++ b/src/widget/resolvable.rs
@@ -38,10 +38,12 @@ impl<'w,E> Resolvable<'w,E> where E: Env + 'static {
     /// if the path particle would resolve to this widget
     #[deprecated]
     #[inline]
-    pub fn resolves_by(&self, p: &EWPSub<E>) -> bool {
+    pub fn resolved_by_path(&self, p: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
         match self {
-            Resolvable::Widget(w) => w.resolves_by(p),
-            Resolvable::Path(w) => p.resolves_to_path(w.refc()), //TODO WRONG use widget's fns
+            Resolvable::Widget(w) => w.resolved_by_path(p),
+            Resolvable::Path(w) => 
+                p.index(0).unwrap().resolves_to_path(w.refc())
+                    .then(|| ResolvesThruResult{ sub_path: p.slice(1..) } ) //TODO this is wrong, as the WidgetID isn't in the WidgetPath, so the current hack relies on the StdPath indeed having the last destination WidgetID. Resolving this requires architecturial modifications, either to enable resolving in this function, which requies the resolve fns to carry &E::Storage for resolving, which is ony possible in the immutable space. Alternatively path needs to somehow carry the last(dest) ID, which doesn't seem to be possible.
         }
     }
     /// extend the path representing the parent of this widget to resolve to this widget
@@ -98,10 +100,12 @@ impl<'w,E> ResolvableMut<'w,E> where E: Env {
     /// is_subpath on the targeted widget
     #[deprecated]
     #[inline]
-    pub fn resolves_by(&self, p: &EWPSub<E>) -> bool {
+    pub fn resolved_by_path(&self, p: &E::WidgetPath) -> Option<ResolvesThruResult<E>> {
         match self {
-            ResolvableMut::Widget(w) => w.resolves_by(p),
-            ResolvableMut::Path(w) => p.resolves_to_path(w.refc()), //TODO WRONG use widget's fns
+            ResolvableMut::Widget(w) => w.resolved_by_path(p),
+            ResolvableMut::Path(w) => 
+                p.index(0).unwrap().resolves_to_path(w.refc())
+                    .then(|| ResolvesThruResult{ sub_path: p.slice(1..) } ) //TODO this is wrong, as the WidgetID isn't in the WidgetPath, so the current hack relies on the StdPath indeed having the last destination WidgetID. Resolving this requires architecturial modifications, either to enable resolving in this function, which requies the resolve fns to carry &E::Storage for resolving, which is ony possible in the immutable space. Alternatively path needs to somehow carry the last(dest) ID, which doesn't seem to be possible.
         }
     }
 }

--- a/src/widget/resolvable.rs
+++ b/src/widget/resolvable.rs
@@ -78,7 +78,7 @@ impl<'w,E> ResolvableMut<'w,E> where E: Env {
     pub fn resolve_child_mut(self, i: E::WidgetPath) -> Result<ResolvableMut<'w,E>,()> {
         match self {
             ResolvableMut::Widget(w) => w.into_resolve_mut(i),
-            ResolvableMut::Path(p) => Ok(ResolvableMut::Path(p.attached_path(&i))),
+            ResolvableMut::Path(p) => Ok(ResolvableMut::Path(p.attached_subpath(&i))),
         }
     }
     #[deprecated]

--- a/src/widget/resolvable.rs
+++ b/src/widget/resolvable.rs
@@ -18,7 +18,7 @@ impl<'w,E> Resolvable<'w,E> where E: Env + 'static {
     pub fn resolve_child(self, sub: E::WidgetPath) -> Result<Resolvable<'w,E>,()> {
         match self {
             Resolvable::Widget(w) => w.into_resolve(sub),
-            Resolvable::Path(p) => Ok(Resolvable::Path(p.attached_path(&sub))),
+            Resolvable::Path(p) => Ok(Resolvable::Path(p.attached_subpath(&sub))),
         }
     }
     /// completely resolve using the storage

--- a/src/widget/resolved.rs
+++ b/src/widget/resolved.rs
@@ -98,7 +98,7 @@ impl<'a,E> Resolved<'a,E> where E: Env {
     }
 
     #[inline]
-    pub fn with_env<F: Env<WidgetPath=E::WidgetPath,Storage=E::Storage>>(self) -> Resolved<'a,F> where E::WidgetPath: WidgetPath<F,SubPath=EWPSub<E>>, EWPSub<E>: SubPath<F>, E::Storage: Widgets<F> {
+    pub fn with_env<F: Env<WidgetPath=E::WidgetPath,Storage=E::Storage>>(self) -> Resolved<'a,F> where E::WidgetPath: WidgetPath<F>, E::Storage: Widgets<F> {
         let stor = self.stor.with_env::<F>();
         let path = rc_path_with_env::<E,F>(self.path.refc());
         stor.widget(path).unwrap()


### PR DESCRIPTION
Rework resolving to use Path fns instead of relying on path fragments (#3)

- phase out and deprecate current form of Path fragments (WidgetPath::SubPath)
