### PR TITLE
Resolve: separate path and direct_path concept

### DIFF
--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -42,7 +42,8 @@ where E: Env {
     fn resolves_thru_child_path(child_path: &Self, sub_path: &Self) -> Option<ResolvesThruResult<E>>;
 
     fn for_child_widget_id(&self, child: E::WidgetID) -> Self;
-    fn for_child_widget_path(&self, child_path: &Self) -> Self;
+    /// `reduce': as 'child_path' is a absolute path and can resolve to the widget itself, the path with the child can be "reduced" to just returning 'child_path'. This reduction should only be done if 'reduce'=true
+    fn for_child_widget_path(&self, child_path: &Self, reduce: bool) -> Self;
 
 
     // fn tip(&self) -> Option<&Self::SubPath>;

--- a/src/path/standard.rs
+++ b/src/path/standard.rs
@@ -132,7 +132,8 @@ impl<E,S> WidgetPath<E> for SimplePath<E,S> where
         self.clone().attached(SubPath::from_id(child_id))
     }
 
-    fn for_child_widget_path(&self, child_path: &Self) -> Self {
+    fn for_child_widget_path(&self, child_path: &Self, reduce: bool) -> Self {
+        if reduce {return child_path.clone()}
         if let Some(tip) = child_path.tip() {
             self.clone().attached(tip.clone()) //TODO doesn't use WidgetID conversion like other fns inconsistent rework StdPath::PathFragment
         }else{

--- a/src/widget/link/mod.rs
+++ b/src/widget/link/mod.rs
@@ -21,7 +21,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn mutate_at<O>(&mut self, f: fn(WidgetRefMut<E>,&mut E::Context,E::WidgetPath), o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::MutateWidget{path: self.widget.short_path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::MutateWidget{path: self.widget.direct_path.refc(),f},o,p)
     }
     /// Enqueue mutable access to this widget
     #[inline] 
@@ -30,7 +30,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn mutate_closure_at<O>(&mut self, f: Box<dyn FnOnce(WidgetRefMut<E>,&mut E::Context,E::WidgetPath)+'static>, o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::MutateWidgetClosure{path: self.widget.short_path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::MutateWidgetClosure{path: self.widget.direct_path.refc(),f},o,p)
     }
     /// Enqueue message-style invoking of [WidgetMut::message]
     #[inline]
@@ -40,7 +40,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     /// Enqueue message-style invoking of [WidgetMut::message]
     #[inline]
     pub fn message_mut_at<O>(&mut self, m: E::Message, o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::MutMessage{path: self.widget.short_path.refc(),msg:m},o,p)
+        self.enqueue(StdEnqueueable::MutMessage{path: self.widget.direct_path.refc(),msg:m},o,p)
     }
     /// Enqueue immutable access to this widget
     #[inline] 
@@ -49,7 +49,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn later_at<O>(&mut self, f: fn(WidgetRef<E>,&mut E::Context), o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::AccessWidget{path: self.widget.short_path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::AccessWidget{path: self.widget.direct_path.refc(),f},o,p)
     }
     /// Enqueue immutable access to this widget
     #[inline] 
@@ -58,22 +58,22 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn later_closure_at<O>(&mut self, f: Box<dyn FnOnce(WidgetRef<E>,&mut E::Context)+Sync>, o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::AccessWidgetClosure{path: self.widget.short_path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::AccessWidgetClosure{path: self.widget.direct_path.refc(),f},o,p)
     }
     #[inline]
     pub fn enqueue_invalidate(&mut self) {
-        self.enqueue(StdEnqueueable::InvalidateWidget{path: self.widget.short_path.refc()},StdOrder::PreRender,0)
+        self.enqueue(StdEnqueueable::InvalidateWidget{path: self.widget.direct_path.refc()},StdOrder::PreRender,0)
     }
     /// Mark the current widget as validated
     /// 
     /// This should and should only be called from widget's render fn
     #[inline]
     pub fn enqueue_validate_render(&mut self) {
-        self.enqueue(StdEnqueueable::ValidateWidgetRender{path: self.widget.short_path.refc()},StdOrder::RenderValidation,0)
+        self.enqueue(StdEnqueueable::ValidateWidgetRender{path: self.widget.direct_path.refc()},StdOrder::RenderValidation,0)
     }
     #[inline]
     pub fn enqueue_validate_size(&mut self, s: ESize<E>) {
-        self.enqueue(StdEnqueueable::ValidateWidgetSize{path: self.widget.short_path.refc(),size: s},StdOrder::RenderValidation,0)
+        self.enqueue(StdEnqueueable::ValidateWidgetSize{path: self.widget.direct_path.refc(),size: s},StdOrder::RenderValidation,0)
     }
 
     #[inline]
@@ -87,8 +87,8 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
 
     #[inline]
-    pub fn short_path(&self) -> E::WidgetPath {
-        self.widget.short_path.refc()
+    pub fn direct_path(&self) -> E::WidgetPath {
+        self.widget.direct_path.refc()
     }
 
     #[inline]
@@ -208,7 +208,7 @@ impl<'c,E> Link<'c,E> where E: Env {
                 let cpath = w.in_parent_path(path.refc()).into();
                 r = Resolved {
                     path: cpath.refc(),
-                    short_path: cpath,
+                    direct_path: cpath,
                     wref: w,
                     stor: self.widget.stor,
                 };
@@ -272,7 +272,7 @@ impl<'c,E> Link<'c,E> where E: Env {
             Resolvable::Widget(w) => {
                 r = Resolved {
                     path: path.refc(),
-                    short_path: path,
+                    direct_path: path,
                     wref: w,
                     stor: self.widget.stor,
                 };
@@ -305,7 +305,7 @@ impl<'c,E> Link<'c,E> where E: Env {
             Resolvable::Widget(w) => {
                 r = Resolved {
                     path: path.refc(),
-                    short_path: path,
+                    direct_path: path,
                     wref: w,
                     stor: self.widget.stor,
                 };

--- a/src/widget/link/mod.rs
+++ b/src/widget/link/mod.rs
@@ -21,7 +21,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn mutate_at<O>(&mut self, f: fn(WidgetRefMut<E>,&mut E::Context,E::WidgetPath), o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::MutateWidget{path: self.widget.path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::MutateWidget{path: self.widget.short_path.refc(),f},o,p)
     }
     /// Enqueue mutable access to this widget
     #[inline] 
@@ -30,7 +30,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn mutate_closure_at<O>(&mut self, f: Box<dyn FnOnce(WidgetRefMut<E>,&mut E::Context,E::WidgetPath)+'static>, o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::MutateWidgetClosure{path: self.widget.path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::MutateWidgetClosure{path: self.widget.short_path.refc(),f},o,p)
     }
     /// Enqueue message-style invoking of [WidgetMut::message]
     #[inline]
@@ -40,7 +40,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     /// Enqueue message-style invoking of [WidgetMut::message]
     #[inline]
     pub fn message_mut_at<O>(&mut self, m: E::Message, o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::MutMessage{path: self.widget.path.refc(),msg:m},o,p)
+        self.enqueue(StdEnqueueable::MutMessage{path: self.widget.short_path.refc(),msg:m},o,p)
     }
     /// Enqueue immutable access to this widget
     #[inline] 
@@ -49,7 +49,7 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn later_at<O>(&mut self, f: fn(WidgetRef<E>,&mut E::Context), o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::AccessWidget{path: self.widget.path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::AccessWidget{path: self.widget.short_path.refc(),f},o,p)
     }
     /// Enqueue immutable access to this widget
     #[inline] 
@@ -58,22 +58,22 @@ impl<'c,E> Link<'c,E> where E: Env {
     }
     #[inline] 
     pub fn later_closure_at<O>(&mut self, f: Box<dyn FnOnce(WidgetRef<E>,&mut E::Context)+Sync>, o: O, p: i64) where ECQueue<E>: Queue<StdEnqueueable<E>,O> {
-        self.enqueue(StdEnqueueable::AccessWidgetClosure{path: self.widget.path.refc(),f},o,p)
+        self.enqueue(StdEnqueueable::AccessWidgetClosure{path: self.widget.short_path.refc(),f},o,p)
     }
     #[inline]
     pub fn enqueue_invalidate(&mut self) {
-        self.enqueue(StdEnqueueable::InvalidateWidget{path: self.widget.path.refc()},StdOrder::PreRender,0)
+        self.enqueue(StdEnqueueable::InvalidateWidget{path: self.widget.short_path.refc()},StdOrder::PreRender,0)
     }
     /// Mark the current widget as validated
     /// 
     /// This should and should only be called from widget's render fn
     #[inline]
     pub fn enqueue_validate_render(&mut self) {
-        self.enqueue(StdEnqueueable::ValidateWidgetRender{path: self.widget.path.refc()},StdOrder::RenderValidation,0)
+        self.enqueue(StdEnqueueable::ValidateWidgetRender{path: self.widget.short_path.refc()},StdOrder::RenderValidation,0)
     }
     #[inline]
     pub fn enqueue_validate_size(&mut self, s: ESize<E>) {
-        self.enqueue(StdEnqueueable::ValidateWidgetSize{path: self.widget.path.refc(),size: s},StdOrder::RenderValidation,0)
+        self.enqueue(StdEnqueueable::ValidateWidgetSize{path: self.widget.short_path.refc(),size: s},StdOrder::RenderValidation,0)
     }
 
     #[inline]
@@ -199,7 +199,6 @@ impl<'c,E> Link<'c,E> where E: Env {
     #[inline]
     pub fn for_child<'s>(&'s mut self, i: usize) -> Result<Link<E>,GuionError<E>> where 'c: 's { //TODO rename to child(i), use with_child_specific
         let path = self.widget.path.refc();
-        let stor = self.widget.stor;
 
         let c = self.widget.child(i)?;
         let mut r;
@@ -211,12 +210,12 @@ impl<'c,E> Link<'c,E> where E: Env {
                     path: cpath.refc(),
                     short_path: cpath,
                     wref: w,
-                    stor,
+                    stor: self.widget.stor,
                 };
             },
             Resolvable::Path(w) => {
                 let cpath = path.for_child_widget_path(&w,false);
-                r = stor.widget(w)?;
+                r = self.widget.stor.widget(w)?;
                 r.path = cpath;
             }
         }
@@ -275,7 +274,7 @@ impl<'c,E> Link<'c,E> where E: Env {
                     path: path.refc(),
                     short_path: path,
                     wref: w,
-                    stor: &self.widget.stor,
+                    stor: self.widget.stor,
                 };
             },
             Resolvable::Path(w) => {
@@ -308,7 +307,7 @@ impl<'c,E> Link<'c,E> where E: Env {
                     path: path.refc(),
                     short_path: path,
                     wref: w,
-                    stor: &self.widget.stor,
+                    stor: self.widget.stor,
                 };
             },
             Resolvable::Path(w) => {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -64,7 +64,7 @@ pub trait Widget<E>: WBase<E> where E: Env + 'static {
     #[deprecated]
     fn child_paths(&self, own_path: E::WidgetPath) -> Vec<E::WidgetPath> {
         (0..self.childs())
-            .map(#[inline] |i| self.child(i).unwrap().in_parent_path(own_path.refc()) )
+            .map(#[inline] |i| self.child(i).unwrap().in_parent_path(own_path.refc(),todo!("TODO")) )
             .collect::<Vec<_>>()
     }
 

--- a/src/widget/resolvable.rs
+++ b/src/widget/resolvable.rs
@@ -47,12 +47,12 @@ impl<'w,E> Resolvable<'w,E> where E: Env + 'static {
         }
     }
     /// Extend the path representing the parent of this widget to resolve to this widget
-    #[deprecated]
+    #[deprecated] //TODO stabilize
     #[inline]
-    pub fn in_parent_path(&self, parent: E::WidgetPath) -> E::WidgetPath {
+    pub fn in_parent_path(&self, parent: E::WidgetPath, reduce: bool) -> E::WidgetPath {
         match self {
             Self::Widget(w) => w.in_parent_path(parent),
-            Self::Path(w) => w.refc().into(), //TODO WRONG use widget's fns
+            Self::Path(w) => parent.for_child_widget_path(w,reduce) //TODO WRONG use widget's fns
         }
     }
 

--- a/src/widget/resolved.rs
+++ b/src/widget/resolved.rs
@@ -142,6 +142,8 @@ impl<'a,E> DerefMut for ResolvedMut<'a,E> where E: Env {
 impl<'a,E> Clone for Resolved<'a,E> where E: Env {
     #[inline]
     fn clone(&self) -> Self {
-        self.stor.widget(self.path.refc()).unwrap()
+        let mut s = self.stor.widget(self.short_path.refc()).unwrap();
+        s.path = self.path.refc();
+        s
     }
 }

--- a/src/widget/resolved.rs
+++ b/src/widget/resolved.rs
@@ -6,14 +6,14 @@ use std::ops::{DerefMut, Deref};
 pub struct Resolved<'a,E> where E: Env {
     pub wref: WidgetRef<'a,E>,
     pub path: E::WidgetPath,
-    pub short_path: E::WidgetPath,
+    pub direct_path: E::WidgetPath,
     pub stor: &'a E::Storage,
 }
 /// A mutable reference to a resolved [`Widget`][WidgetMut]
 pub struct ResolvedMut<'a,E> where E: Env {
     pub wref: WidgetRefMut<'a,E>,
     pub path: E::WidgetPath,
-    pub short_path: E::WidgetPath,
+    pub direct_path: E::WidgetPath,
 }
 
 impl<'a,E> Resolved<'a,E> where E: Env {
@@ -72,7 +72,7 @@ impl<'a,E> Resolved<'a,E> where E: Env {
         Resolved{
             wref: Box::new(&*self.wref),
             path: self.path.clone(),
-            short_path: self.short_path.clone(),
+            direct_path: self.direct_path.clone(),
             stor: &self.stor,
         }
     }
@@ -142,7 +142,7 @@ impl<'a,E> DerefMut for ResolvedMut<'a,E> where E: Env {
 impl<'a,E> Clone for Resolved<'a,E> where E: Env {
     #[inline]
     fn clone(&self) -> Self {
-        let mut s = self.stor.widget(self.short_path.refc()).unwrap();
+        let mut s = self.stor.widget(self.direct_path.refc()).unwrap();
         s.path = self.path.refc();
         s
     }

--- a/src/widget/resolved.rs
+++ b/src/widget/resolved.rs
@@ -6,12 +6,14 @@ use std::ops::{DerefMut, Deref};
 pub struct Resolved<'a,E> where E: Env {
     pub wref: WidgetRef<'a,E>,
     pub path: E::WidgetPath,
+    pub short_path: E::WidgetPath,
     pub stor: &'a E::Storage,
 }
 /// A mutable reference to a resolved [`Widget`][WidgetMut]
 pub struct ResolvedMut<'a,E> where E: Env {
     pub wref: WidgetRefMut<'a,E>,
     pub path: E::WidgetPath,
+    pub short_path: E::WidgetPath,
 }
 
 impl<'a,E> Resolved<'a,E> where E: Env {
@@ -70,6 +72,7 @@ impl<'a,E> Resolved<'a,E> where E: Env {
         Resolved{
             wref: Box::new(&*self.wref),
             path: self.path.clone(),
+            short_path: self.short_path.clone(),
             stor: &self.stor,
         }
     }

--- a/src/widget/root.rs
+++ b/src/widget/root.rs
@@ -39,7 +39,7 @@ pub fn resolve_in_root<'l,'s,E>(root: &'s dyn Widget<E>, sub: E::WidgetPath, abs
             Ok(Resolved {
                 wref: w,
                 path: abs_path.clone(),
-                short_path: abs_path,
+                direct_path: abs_path,
                 stor
             }),
         Resolvable::Path(p) => {
@@ -59,7 +59,7 @@ pub fn resolve_in_root_mut<E: Env>(
 ) -> Result<ResolvedMut<E>,GuionError<E>> {
     
     let final_path = resolve_in_root::<E>(root_in_stor(stor), sub, abs_path.refc(), stor)
-        .map(#[inline] |e| e.short_path )?;
+        .map(#[inline] |e| e.direct_path )?;
 
     let w = root_in_stor_mut(stor)
         .resolve_mut(final_path.refc())
@@ -70,6 +70,6 @@ pub fn resolve_in_root_mut<E: Env>(
     Ok(ResolvedMut {
         wref: w,
         path: abs_path,
-        short_path: final_path,
+        direct_path: final_path,
     })
 }

--- a/src/widget/root.rs
+++ b/src/widget/root.rs
@@ -31,28 +31,45 @@ pub trait Widgets<E>: Sized + 'static where E: Env {
 }
 //#[doc(hidden)]
 /// Used by [`Widgets::widget`] implementations
-pub fn resolve_in_root<E: Env>(w: &dyn Widget<E>, p: E::WidgetPath) -> Result<(WidgetRef<E>,E::WidgetPath),GuionError<E>> {
-    let r = w.resolve(p.refc())?;
+pub fn resolve_in_root<'l,'s,E>(root: &'s dyn Widget<E>, sub: E::WidgetPath, abs_path: E::WidgetPath, stor: &'l E::Storage) -> Result<Resolved<'s,E>,GuionError<E>> where E: Env, 'l: 's {
+    let r = root.resolve(sub.refc())?;
     
     match r {
         Resolvable::Widget(w) => 
-            Ok(
-                (w,From::from(p))
-            ),
-        Resolvable::Path(p) => resolve_in_root(w,p),
+            Ok(Resolved {
+                wref: w,
+                path: abs_path.clone(),
+                short_path: abs_path,
+                stor
+            }),
+        Resolvable::Path(p) => {
+            let mut r = stor.widget(p)?;
+            r.path = abs_path;
+            Ok(r)
+        },
     }
 }
 //#[doc(hidden)]
 /// Used by [`Widgets::widget_mut`](Widgets::widget_mut) implementations
-pub fn resolve_in_root_mut<E: Env>(w: &mut dyn WidgetMut<E>, p: E::WidgetPath) -> Result<(WidgetRefMut<E>,E::WidgetPath),GuionError<E>> {
-    let final_path = resolve_in_root::<E>(w.base(),p)
-        .map(#[inline] |e| e.1 )?;
+pub fn resolve_in_root_mut<E: Env>(
+    stor: &mut E::Storage,
+    root_in_stor: impl FnOnce(&E::Storage) -> &dyn Widget<E>,
+    root_in_stor_mut: impl FnOnce(&mut E::Storage) -> &mut dyn WidgetMut<E>,
+    sub: E::WidgetPath, abs_path: E::WidgetPath,
+) -> Result<ResolvedMut<E>,GuionError<E>> {
+    
+    let final_path = resolve_in_root::<E>(root_in_stor(stor), sub, abs_path.refc(), stor)
+        .map(#[inline] |e| e.short_path )?;
 
-    Ok((
-        w.resolve_mut(final_path.refc())
-            .unwrap()
-            .as_widget()
-            .unwrap_nodebug(),
-        final_path
-    ))
+    let w = root_in_stor_mut(stor)
+        .resolve_mut(final_path.refc())
+        .unwrap()
+        .as_widget()
+        .unwrap_nodebug(); 
+
+    Ok(ResolvedMut {
+        wref: w,
+        path: abs_path,
+        short_path: final_path,
+    })
 }


### PR DESCRIPTION
- Resolved::path is now the full path which would resolver over all widgets it previously did. Useful for e.g. tabulating to parents
- short_path/direct_path is the shortest path to resolve to the desired widget, used in pure resolve functions
